### PR TITLE
feat: 添加 globPattern 和 globIgnore 支持，使用 tar-stream 打包

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ module.exports = {
   release_name: dayjs().format('YYYY-MM-DD_HH_mm'),    // 版本名称
   local_target: path.resolve('dist'),                  // uni-app build 后，打包文件的所在位置
   tar: false,                                          // 不开启压缩上传
+  localOnly: false,                                    // （选填）本地打包模式，只生成 tar 包不上传服务器，默认: false
   includes: [],                                        // （选填）只打包匹配的文件/目录，支持 glob 语法，默认: ['**/*']
   excludes: [],                                        // （选填）排除匹配的文件/目录，支持 glob 语法，默认: []
   afterUpload(ssh): Promise<void>,                     // （选填）执行完上传后的回调函数，参考下方 afterUpload 示例
@@ -100,6 +101,29 @@ module.exports = {
   ],
 }
 ```
+
+#### 本地打包模式（localOnly）
+
+如果只需要在本地生成 tar 包，而不需要上传到服务器，可以使用 `localOnly` 选项：
+
+```javascript
+const { NodeSSH } = require('node-deploy');
+
+NodeSSH.deploy({
+  localOnly: true,                          // 开启本地打包模式
+  tar: true,                                // 必须开启 tar 压缩
+  local_target: path.resolve('dist'),       // 需要打包的目录
+  includes: ['**/*'],                       // （选填）只打包匹配的文件
+  excludes: ['node_modules/**', '.git/**'], // （选填）排除匹配的文件
+  // 不需要配置 ssh_configs（即使配置了也不会上传）
+});
+```
+
+使用 `localOnly` 模式时：
+- 会在项目根目录生成 `build.tar.gz` 文件
+- 自动显示打包内容预览（前 50 个文件）
+- **不会上传到服务器**（即使配置了 `ssh_configs` 也不会上传）
+- 适用于需要手动部署或传输打包文件的场景
 
 ### h5 项目参考配置
 ```javascript

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ module.exports = {
   release_name: dayjs().format('YYYY-MM-DD_HH_mm'),    // 版本名称
   local_target: path.resolve('dist'),                  // uni-app build 后，打包文件的所在位置
   tar: false,                                          // 不开启压缩上传
-  includes: [],                                        // （选填）只需要上传的文件
-  excludes: [],                                        // （选填）不需要上传的文件
+  includes: [],                                        // （选填）只打包匹配的文件/目录，支持 glob 语法，默认: ['**/*']
+  excludes: [],                                        // （选填）排除匹配的文件/目录，支持 glob 语法，默认: []
   afterUpload(ssh): Promise<void>,                     // （选填）执行完上传后的回调函数，参考下方 afterUpload 示例
   ssh_configs: [
     {
@@ -74,6 +74,30 @@ module.exports = {
       }
     },
   ]
+}
+```
+
+#### Glob 语法说明
+
+`includes` 和 `excludes` 参数使用 [glob](https://www.npmjs.com/package/glob) 语法进行文件匹配：
+
+```javascript
+{
+  // 排除特定目录
+  excludes: [
+    'node_modules/**',      // 排除根目录的 node_modules
+    '**/node_modules/**',   // 排除所有层级的 node_modules
+    '.git/**',              // 排除 .git 目录
+    '**/.DS_Store',         // 排除所有 .DS_Store 文件
+    '*.log',                // 排除根目录的所有 .log 文件
+  ],
+
+  // 只打包特定文件
+  includes: [
+    'dist/**',              // 只打包 dist 目录
+    'public/**',            // 只打包 public 目录
+    '*.html',               // 只打包根目录的 HTML 文件
+  ],
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
 /* eslint-disable no-console */
 const os = require('os');
 const path = require('path');
+const fs = require('fs');
 const crypto = require('crypto');
+const zlib = require('zlib');
 const { exec } = require('child-process-promise');
 const { NodeSSH: OriginNodeSSH } = require('node-ssh');
 const _ = require('lodash');
+const { glob } = require('glob');
+const tar = require('tar-stream');
 const DeployToOss = require('./deploy-ali-oss');
 const DeployToCos = require('./deploy-tencent-cos');
 
@@ -27,6 +31,8 @@ class NodeSSH extends OriginNodeSSH {
       excludes = [],
       includes = [],
       versionsRetainedNumber = 1,
+      globPattern = '**/*', // 新增：glob 匹配模式（传了就用 Node.js tar-stream）
+      globIgnore = [], // 新增：glob 排除模式
     } = this.deployConfig = deployConfig;
 
     this.afterUpload = afterUpload;
@@ -34,6 +40,8 @@ class NodeSSH extends OriginNodeSSH {
     this.tar = tar;
     this.includes = includes;
     this.excludes = excludes;
+    this.globPattern = globPattern;
+    this.globIgnore = globIgnore;
     this.versionsRetainedNumber = Math.max(versionsRetainedNumber, 1);
     this.projectDir = project_dir; // /var/www/xxx-frontend
     this.namespace = namespace; // app
@@ -80,19 +88,115 @@ class NodeSSH extends OriginNodeSSH {
     }
   }
 
+  // 使用 Node.js tar-stream 打包（支持 globPattern 和 globIgnore）
+  // globIgnore 语法示例：
+  //   - 'node_modules/**'     -> 只排除根目录的 node_modules
+  //   - '**/node_modules/**'  -> 排除所有层级的 node_modules
+  //   - '.git/**'             -> 排除根目录的 .git
+  //   - '**/.DS_Store'        -> 排除所有 .DS_Store 文件
+  async createTarWithGlobPattern(localTarPath) {
+    const pack = tar.pack();
+    const gzip = zlib.createGzip();
+    const output = fs.createWriteStream(localTarPath);
+
+    // 管道：pack -> gzip -> output
+    pack.pipe(gzip).pipe(output);
+
+    // 使用 glob 获取文件，同时应用 globIgnore 排除
+    const allFiles = await glob(this.globPattern, {
+      cwd: this.localTarget,
+      dot: true,
+      nodir: false,
+      ignore: this.globIgnore,
+    });
+
+    const filesToPack = allFiles.sort();
+
+    console.log(`找到 ${filesToPack.length} 个文件/目录需要打包`);
+    console.log(`包含模式: ${this.globPattern}`);
+    console.log(`排除模式: ${JSON.stringify(this.globIgnore)}`);
+
+    // 逐个添加文件到 tar
+    let processed = 0;
+    for (const file of filesToPack) {
+      const fullPath = path.join(this.localTarget, file);
+      const stats = fs.statSync(fullPath);
+
+      if (stats.isDirectory()) {
+        pack.entry({ name: file, type: 'directory' });
+      } else {
+        const content = fs.readFileSync(fullPath);
+        pack.entry({ name: file, size: content.length }, content);
+      }
+
+      processed++;
+      if (processed % 100 === 0) {
+        console.log(`已处理 ${processed}/${filesToPack.length} 个文件...`);
+      }
+    }
+
+    return new Promise((resolve, reject) => {
+      output.on('finish', () => {
+        console.log(`✅ Tar 打包完成: ${localTarPath}`);
+        resolve();
+      });
+      output.on('error', reject);
+      pack.finalize();
+    });
+  }
+
+  // 使用系统 tar 命令打包（旧版，兼容，使用 excludes）
+  async createTarWithSystem(localTarPath) {
+    let tarCommand = `COPYFILE_DISABLE=1 tar -czvf ${localTarPath} -C ${this.localTarget}`;
+
+    // 先添加所有 excludes
+    this.excludes.forEach((item) => {
+      tarCommand += ` --exclude='${item}'`;
+    });
+
+    // 再添加 includes (如果有的话)
+    this.includes.forEach((item) => {
+      tarCommand += ` --include='${item}'`;
+    });
+
+    // 最后添加要打包的目录
+    tarCommand += ' .';
+
+    console.log(`exec(${tarCommand})`);
+    await exec(tarCommand);
+  }
+
   async upload() {
     if (this.tar) {
-      const localTarPath = path.posix.join('/tmp', `build-${crypto.randomBytes(4).toString('hex')}.tar.gz`);
-      let tarCommand = `COPYFILE_DISABLE=1 tar -czvf ${localTarPath} -C ${this.localTarget}`;
-      this.excludes.forEach((item) => {
-        tarCommand += ` --exclude='${item}'`;
-      });
-      this.includes.forEach((item) => {
-        tarCommand += ` --include='${item}'`;
-      });
-      tarCommand += ' .';
-      console.log(`exec(${tarCommand})`);
-      await exec(tarCommand);
+      // 如果是本地模式或没有 SSH 配置，直接生成到项目目录
+      const noSSH = !this.deployConfig.ssh_configs || this.deployConfig.ssh_configs.length === 0;
+      const localTarPath = (this.deployConfig.localOnly || noSSH)
+        ? path.resolve('./build.tar.gz')
+        : path.posix.join('/tmp', `build-${crypto.randomBytes(4).toString('hex')}.tar.gz`);
+
+      // 根据配置选择打包方式
+      // 如果传了 globIgnore 或 globPattern 不是默认的，使用 Node.js tar-stream
+      if (this.globIgnore?.length > 0 || this.globPattern !== '**/*') {
+        console.log('使用 Node.js tar-stream 打包（支持 globPattern/globIgnore）...');
+        await this.createTarWithGlobPattern(localTarPath);
+      } else {
+        console.log('使用系统 tar 命令打包...');
+        await this.createTarWithSystem(localTarPath);
+      }
+
+      // 如果是本地模式，直接返回
+      if (this.deployConfig.localOnly) {
+        console.log(`✅ 本地打包完成: ${localTarPath}`);
+
+        // 列出打包内容供用户检查
+        console.log('\n📦 打包内容预览:');
+        const { stdout } = await exec(`tar -tzf ${localTarPath} | head -50`);
+        console.log(stdout);
+        const { stdout: total } = await exec(`tar -tzf ${localTarPath} | wc -l`);
+        console.log(`... 共 ${total.trim()} 个文件\n`);
+        return;
+      }
+
       const remoteTarPath = path.posix.join(this.newReleaseDir, 'build.tar.gz');
       console.log(`putFile(${localTarPath}, ${remoteTarPath})`);
       await this.putFile(localTarPath, remoteTarPath);
@@ -125,6 +229,19 @@ class NodeSSH extends OriginNodeSSH {
   }
 
   static async deploy({ ssh_configs, ...deployConfig }) {
+    // 本地模式：如果没有 SSH 配置或使用 globPattern/globIgnore，直接打包
+    const hasGlobConfig = deployConfig.globIgnore?.length > 0 || deployConfig.globPattern !== '**/*';
+    if (!ssh_configs || ssh_configs.length === 0 || deployConfig.localOnly || hasGlobConfig) {
+      const ssh = new this(deployConfig);
+      try {
+        await ssh.upload();
+      } catch (err) {
+        console.error(err);
+        process.exit(1);
+      }
+      return;
+    }
+
     for (const sshConfig of ssh_configs) {
       const ssh = new this(deployConfig);
       try {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "fs-extra": "^9.0.1",
     "glob": "^10.5.0",
     "lodash": "^4.17.21",
-    "node-ssh": "^13.1.0"
+    "node-ssh": "^13.1.0",
+    "tar-stream": "^3.1.7"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.35.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ specifiers:
   glob: ^10.5.0
   lodash: ^4.17.21
   node-ssh: ^13.1.0
+  tar-stream: ^3.1.7
   typescript: ^4.9.5
 
 dependencies:
@@ -25,6 +26,7 @@ dependencies:
   glob: 10.5.0
   lodash: 4.17.21
   node-ssh: 13.1.0
+  tar-stream: 3.1.7
 
 devDependencies:
   '@antfu/eslint-config': 0.35.3_7sjm5uif3lrlodkmlzqsvrpzla
@@ -656,8 +658,26 @@ packages:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
     dev: false
 
+  /b4a/1.7.3:
+    resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+    dev: false
+
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  /bare-events/2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+    dev: false
 
   /bcrypt-pbkdf/1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
@@ -1602,6 +1622,14 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /events-universal/1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+    dev: false
+
   /extend-shallow/2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
@@ -1620,6 +1648,10 @@ packages:
 
   /fast-deep-equal/3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  /fast-fifo/1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+    dev: false
 
   /fast-glob/3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
@@ -3160,6 +3192,17 @@ packages:
     engines: {node: '>=4.0.0'}
     dev: false
 
+  /streamx/2.23.0:
+    resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    dev: false
+
   /string-width/4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -3268,6 +3311,25 @@ packages:
     dependencies:
       tslib: 2.6.2
     dev: true
+
+  /tar-stream/3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+    dependencies:
+      b4a: 1.7.3
+      fast-fifo: 1.3.2
+      streamx: 2.23.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    dev: false
+
+  /text-decoder/1.2.3:
+    resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
+    dependencies:
+      b4a: 1.7.3
+    transitivePeerDependencies:
+      - react-native-b4a
+    dev: false
 
   /text-table/0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}


### PR DESCRIPTION
## 功能特性

- ✅ 新增 `globPattern` 配置项，支持 glob 匹配模式
- ✅ 新增 `globIgnore` 配置项，支持 glob 排除模式
- ✅ 使用 Node.js `tar-stream` 实现打包功能
- ✅ 保留系统 tar 命令，兼容旧版 `excludes`/`includes` 配置
- ✅ 支持本地模式（`localOnly`）直接打包到项目目录
- ✅ 添加打包内容预览功能

## globIgnore 语法示例

```javascript
{
  globIgnore: [
    'node_modules/**',     // 只排除根目录的 node_modules
    '**/node_modules/**',  // 排除所有层级的 node_modules
    '.git/**',             // 排除根目录的 .git
    '**/.DS_Store'         // 排除所有 .DS_Store 文件
  ]
}
```

## 测试计划

- [ ] 测试 globPattern 默认值 `**/*`
- [ ] 测试 globIgnore 排除模式
- [ ] 测试本地模式打包
- [ ] 测试 SSH 部署模式
- [ ] 验证与旧版配置的兼容性

🤖 Generated with [Claude Code](https://claude.com/claude-code)