### PR TITLE
fix: 修复 SSH 断开时未处理的 ECONNRESET 错误

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,15 +231,24 @@ class NodeSSH extends OriginNodeSSH {
     // SSH 部署模式
     for (const sshConfig of ssh_configs) {
       const ssh = new this(deployConfig);
+      let lastSSH;
       try {
-        const lastSSH = await ssh.connect2(sshConfig);
+        lastSSH = await ssh.connect2(sshConfig);
         console.log('ssh connected');
 
         await lastSSH.upload();
-        ssh.dispose();
       } catch (err) {
         console.error(err);
         process.exit(1);
+      } finally {
+        // 静默处理连接关闭时可能触发的 ECONNRESET 错误（远端主动断开属正常行为）
+        if (ssh.connection) {
+          ssh.connection.on('error', () => {});
+        }
+        if (lastSSH && lastSSH !== ssh && lastSSH.connection) {
+          lastSSH.connection.on('error', () => {});
+        }
+        ssh.dispose();
       }
     }
   }


### PR DESCRIPTION
部署完成后远端服务器重置 TCP 连接属正常行为，但 ssh2 的
Client 实例会 emit error 事件，由于未注册监听器导致 Node.js
抛出 unhandled error 并以 exit code 1 退出。

- 将 lastSSH 声明提到 try 块外，确保 finally 可访问
- 在 dispose() 前为 connection 注册空 error 监听器， 静默处理预期内的 ECONNRESET
- 将 ssh.dispose() 移至 finally 块，确保始终执行